### PR TITLE
Added constructor parsing support

### DIFF
--- a/.ctags
+++ b/.ctags
@@ -3,6 +3,7 @@
 --regex-pony=/^[ \t]*actor[ \t]+([a-zA-Z0-9_]+)/\1/a,actor/
 --regex-pony=/^[ \t]*be[ \t]+([a-zA-Z0-9_]+)/\1/b,behavior/
 --regex-pony=/^[ \t]*class([ \t]+(iso|trn|ref|val|box|tag))?[ \t]+([a-zA-Z0-9_]+)/\3/c,class/
+--regex-pony=/^[ \t]*new([ \t]+(iso|trn|ref|val|box|tag))?[ \t]+([a-zA-Z0-9_]+)/\3/n,new/
 --regex-pony=/^[ \t]*fun([ \t]+(iso|trn|ref|val|box|tag))?[ \t]+([a-zA-Z0-9_]+)/\3/f,function/
 --regex-pony=/^[ \t]*interface([ \t]+(iso|trn|ref|val|box|tag))?[ \t]+([a-zA-Z0-9_]+)/\3/i,interface/
 --regex-pony=/^[ \t]*primitive[ \t]+([a-zA-Z0-9_]+)/\1/p,primitive/


### PR DESCRIPTION
The constructor cannot be parsed by `ctags`, this PR adds the constructor parsing rules.